### PR TITLE
feat: align site with Basix identity

### DIFF
--- a/src/app/components/cta.tsx
+++ b/src/app/components/cta.tsx
@@ -1,3 +1,6 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
 export default function CTA() {
     return (
         <section id="cta" className="bg-neutral-100 text-neutral-900 py-20 px-4">
@@ -6,13 +9,13 @@ export default function CTA() {
                     Vamos escalar juntos?
                 </h2>
                 <p>Peça uma demonstração da Basix funcionando na prática — com os mesmos fluxos, painéis e automações que usamos todos os dias.</p>
-                <div>
-                    <a href="#assinar">
-                        Quero ver como funciona
-                    </a>
-                    <a href="">
-                        Agendar conversa
-                    </a>
+                <div className="mt-6 flex justify-center gap-4">
+                    <Button asChild>
+                        <Link href="/insider">Quero ver como funciona</Link>
+                    </Button>
+                    <Button asChild variant="outline">
+                        <Link href="#contato">Agendar conversa</Link>
+                    </Button>
                 </div>
             </div>
         </section>

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -12,6 +12,8 @@ export default function Footer() {
                 <p className="text-neutral-400">&copy; {new Date().getFullYear()} Todos os direitos reservados.</p>
 
                 <div className="flex space-x-4">
+                    <Link href="/insider" className="hover:text-neutral-100">Insider</Link>
+                    <a href="#contato" className="hover:text-neutral-100">Contato</a>
                     <a href="https://www.instagram.com/basix.digital/" className="hover:text-neutral-100">Instagram</a>
                 </div>
             </div>

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -11,7 +11,8 @@ export default function Header() {
                 <nav className="hidden md:flex space-x-6 text-sm font-medium text-neutral-800">
                     <a href="#sobre" className="hover:text-neutral-900">Sobre</a>
                     <a href="#solucoes" className="hover:text-neutral-900">Soluções</a>
-                    <a href="#perfil" className="hover:text-neutral-900">Perfil Ideal</a>
+                    <a href="#perfil" className="hover:text-neutral-900">Nossos desafios</a>
+                    <Link href="/insider" className="hover:text-neutral-900">Insider</Link>
                     <a href="#contato" className="hover:text-neutral-900">Contato</a>
                 </nav>
             </div>

--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function Hero() {
@@ -11,14 +12,11 @@ export default function Hero() {
                 <p className="mt-6 text-lg md:text-xl text-neutral-300 max-w-3xl mx-auto">
                     Na Basix, vendemos apenas o que usamos todos os dias. Soluções automatizadas para agências e especialistas que querem escalar com inteligência — sem código, sem complicação.                </p>
                 <div className="mt-10 flex justify-center items-center gap-4 flex-row">
-                    <a
-                        href="#contato"
-                        className="inline-block bg-neutral-100 text-neutral-900 px-6 py-3 rounded-full text-sm font-semibold hover:bg-neutral-100 transition"
-                    >
-                        Quero ver a solução funcionando
-                    </a>
-                    <Button variant="outline" className="ml-4 rounded-full">
-                        Ver pacotes
+                    <Button asChild className="rounded-full">
+                        <Link href="#contato">Quero ver a solução funcionando</Link>
+                    </Button>
+                    <Button asChild variant="outline" className="ml-4 rounded-full">
+                        <Link href="/insider">Entrar para o Insider</Link>
                     </Button>
                 </div>
             </div>

--- a/src/app/components/solutions.tsx
+++ b/src/app/components/solutions.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from '@/components/ui/button';
 import { CheckCircle } from 'lucide-react';
 
@@ -31,7 +32,9 @@ export default function Solutions() {
                                 <p className="text-lg text-neutral-800">{solucao.nome}</p>
                             </div>
                             <p className="text-lg text-neutral-800">{solucao.incluido}</p>
-                            <Button variant="outline" className="ml-4">{solucao.cta}</Button>
+                            <Button asChild variant="outline" className="ml-4">
+                                <Link href="#contato">{solucao.cta}</Link>
+                            </Button>
                         </div>
                     ))}
                 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,14 +49,15 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  /* Basix brand colors */
+  --primary: #00E7B5;
+  --primary-foreground: #0A0A0A;
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --accent: #00E7B5;
+  --accent-foreground: #0A0A0A;
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
@@ -83,14 +84,14 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: #00E7B5;
+  --primary-foreground: #0A0A0A;
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --accent: #00E7B5;
+  --accent-foreground: #0A0A0A;
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,11 +10,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-neutral-900 text-neutral-100 shadow-xs hover:bg-neutral-900/90",
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-transparent shadow-xs hover:bg-neutral-200 hover:text-neutral-900 dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-primary text-primary bg-transparent shadow-xs hover:bg-primary hover:text-primary-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost:


### PR DESCRIPTION
## Summary
- add Basix brand color palette
- link to Insider and contact form across site
- rename "Perfil Ideal" menu entry to "Nossos desafios"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892748b2c18832282ade2c337528c20