### PR TITLE
Add GA conversion trigger on thank you page

### DIFF
--- a/src/app/obrigado/page.tsx
+++ b/src/app/obrigado/page.tsx
@@ -1,10 +1,19 @@
+"use client";
+
 import Link from "next/link";
 import type { Metadata } from "next";
 import { ArrowRight, CheckCircle2, MessageCircle } from "lucide-react";
+import { useEffect } from "react";
 
 import BasixLogoFull from "@/components/basix-logo-full";
 import Footer from "@/components/footer";
 import { Button } from "@/components/ui/button";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
 
 export const metadata: Metadata = {
   title: "Obrigado - Basix Digital",
@@ -13,6 +22,15 @@ export const metadata: Metadata = {
 };
 
 export default function ObrigadoPage() {
+  useEffect(() => {
+    if (typeof window !== "undefined" && typeof window.gtag === "function") {
+      window.gtag("event", "ads_conversion_Enviar_formul_rio_de_le_1", {
+        value: 1,
+        currency: "BRL",
+      });
+    }
+  }, []);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#020540] via-[#060126] to-[#150259] text-white flex flex-col">
       <header className="fixed top-0 w-full z-50 bg-[#020540]/90 backdrop-blur-sm border-b border-[#F244C4]/20">


### PR DESCRIPTION
## Summary
- send the GA4 conversion event on the thank-you page load with default value and currency
- convert the obrigado page to a client component and type the gtag helper

## Testing
- npm run lint (warning about existing hook dependency in text-effect-flipper)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69422b81cb188322b8ab6a09f0f165da)